### PR TITLE
Fix Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "openstudio-analysis", "~> 0.3.5"
 #gem "openstudio-analysis", :path => "../OpenStudio-analysis-gem"
 
 gem "colored", "~> 1.2"
-gem "aws-sdk-core", "2.0.0.rc15"
+gem "aws-sdk-core", "2.0.0.rc14"
 gem "spreadsheet", "0.9.8"
 
 if RUBY_PLATFORM =~ /win32/

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "openstudio-analysis", "~> 0.3.5"
 #gem "openstudio-analysis", :path => "../OpenStudio-analysis-gem"
 
 gem "colored", "~> 1.2"
-gem "aws-sdk-core", "2.0.0.rc14"
 gem "spreadsheet", "0.9.8"
 
 if RUBY_PLATFORM =~ /win32/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,6 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  aws-sdk-core (= 2.0.0.rc14)
   bcl (~> 0.5.4)
   colored (~> 1.2)
   git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     git (1.2.8)
-    jamespath (0.5.0)
+    jamespath (0.5.1)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     mini_portile (0.6.0)
@@ -34,8 +34,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
     nokogiri (1.6.3.1-x86-mingw32)
       mini_portile (= 0.6.0)
     openstudio-analysis (0.3.5)
@@ -59,7 +57,7 @@ GEM
       rubyzip (>= 1.1.6)
     rubyzip (1.1.6)
     semantic (1.3.0)
-    spreadsheet (1.0.0)
+    spreadsheet (0.9.8)
       ruby-ole (>= 1.0)
     systemu (2.6.4)
     uuid (2.3.7)
@@ -68,10 +66,10 @@ GEM
     zliby (0.0.5)
 
 PLATFORMS
-  ruby
   x86-mingw32
 
 DEPENDENCIES
+  aws-sdk-core (= 2.0.0.rc14)
   bcl (~> 0.5.4)
   colored (~> 1.2)
   git
@@ -79,3 +77,4 @@ DEPENDENCIES
   openstudio-aws (~> 0.2.2)
   rake (~> 10.3.2)
   rubyzip
+  spreadsheet (= 0.9.8)


### PR DESCRIPTION
`gemfile` AWS and spreadsheet versions were out of sync with `gemfile.lock` versions, and `gemfile` was pointing to rc15 (broken) instead of rc14 (working). Fixed these inconsistencies and regenerated `gemfile.lock`.
